### PR TITLE
feat: 添加ASN和CN数据库URL的环境变量支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,5 @@ Render 可以直接部署 docker 镜像,不需要 fork 仓库：[Render](https:/
 1. `PORT=7099`  [可选]服务端口
 1. `API_SECRET=123456`  [可选]接口密钥-修改此行为请求头校验的值(多个请以,分隔)(请求header中增加 Authorization:Bearer 123456)
 2. `CITY_DB_REMOTE_URL=https://xxx.com/GeoIP2-City.mmdb`  [可选]city.mmdb远程地址
+3. `ASN_DB_REMOTE_URL=https://xxx.com/GeoLite2-ASN.mmdb`  [可选]ASN.mmdb远程地址
+4. `CN_DB_REMOTE_URL=https://xxx.com/GeoCN.mmdb`  [可选]CN.mmdb远程地址

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -19,6 +19,8 @@ var ApiSecret = os.Getenv("API_SECRET")
 var ApiSecrets = strings.Split(os.Getenv("API_SECRET"), ",")
 
 var CityDBRemoteUrl = os.Getenv("CITY_DB_REMOTE_URL")
+var AsnDBRemoteUrl = os.Getenv("ASN_DB_REMOTE_URL")
+var CnDBRemoteUrl = os.Getenv("CN_DB_REMOTE_URL")
 
 var (
 	RequestRateLimitNum            = env.Int("REQUEST_RATE_LIMIT", 120)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,6 @@ services:
     environment:
       - API_SECRET=123456  # [可选]修改此行为请求头校验的值（前后端统一）
       - TZ=Asia/Shanghai
+      # - CITY_DB_REMOTE_URL=https://xxx.com/GeoIP2-City.mmdb  # [可选]自定义City数据库下载地址
+      # - ASN_DB_REMOTE_URL=https://xxx.com/GeoLite2-ASN.mmdb  # [可选]自定义ASN数据库下载地址
+      # - CN_DB_REMOTE_URL=https://xxx.com/GeoCN.mmdb  # [可选]自定义CN数据库下载地址

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 const (
 	cityDBDefaultURL = "https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb"
 	asnDBURL         = "https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb"
-	cnDBURL          = "http://github.com/ljxi/GeoCN/releases/download/Latest/GeoCN.mmdb"
+	cnDBURL          = "https://github.com/ljxi/GeoCN/releases/download/Latest/GeoCN.mmdb"
 	sessionName      = "session"
 )
 
@@ -80,8 +80,8 @@ func getPort() string {
 
 func loadDatabases() {
 	downloadAndSave("GeoIP-City.mmdb", getCityDBURL())
-	downloadAndSave("Geo-ASN.mmdb", asnDBURL)
-	downloadAndSave("GeoCN.mmdb", cnDBURL)
+	downloadAndSave("Geo-ASN.mmdb", getAsnDBURL())
+	downloadAndSave("GeoCN.mmdb", getCnDBURL())
 
 	openDatabases()
 }
@@ -93,8 +93,22 @@ func getCityDBURL() string {
 	return cityDBDefaultURL
 }
 
+func getAsnDBURL() string {
+	if config.AsnDBRemoteUrl != "" {
+		return config.AsnDBRemoteUrl
+	}
+	return asnDBURL
+}
+
+func getCnDBURL() string {
+	if config.CnDBRemoteUrl != "" {
+		return config.CnDBRemoteUrl
+	}
+	return cnDBURL
+}
+
 func downloadAndSave(filename, url string) {
-	logger.SysLog(fmt.Sprintf("Downloading %s...", filename))
+	logger.SysLog(fmt.Sprintf("Downloading %s from %s...", filename, url))
 	resp, err := http.Get(url)
 	if err != nil {
 		logger.FatalLog("Failed to download %s: %v", filename, err)


### PR DESCRIPTION
feat: 添加ASN和CN数据库URL的环境变量支持

- 新增 ASN_DB_REMOTE_URL 和 CN_DB_REMOTE_URL 环境变量
- 支持所有MMDB数据库下载URL的自定义配置
- 更新文档说明新增的环境变量
- 优化下载日志显示实际使用的URL

自定义下载地址环境变量，可以在原始下载地址前面增加github加速地址
```env
ASN_DB_REMOTE_URL=https://ghproxy.1888866.xyz/https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-ASN.mmdb
CITY_DB_REMOTE_URL=https://ghproxy.1888866.xyz/https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb
CN_DB_REMOTE_URL=https://ghproxy.1888866.xyz/https://github.com/ljxi/GeoCN/releases/download/Latest/GeoCN.mmdb
```

之前只可以自定义CITY_DB_REMOTE_URL，另外两个还是通过github下载，无法自定义下载地址，在国内网络环境还是可能会下载超时。